### PR TITLE
Fix /private directory heading level

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ All of the currently installed NPM modules for the application.
 
 Any public-facing, static assets for your application like your `favicon.ico` file or your app's logo. All files in this folder are mapped to the root `/` URL in your application (e.g., `/public/favicon.ico` would map to `http://localhost:2600/favicon.ico` in development).
 
-## /private
+### /private
 
 Any private assets that you _do not_ want to expose to the public (e.g., a `.pem` file). This folder is only accessible on the server.
 


### PR DESCRIPTION
Hi, I saw your link to Joystick on Hacker News and while I was browsing the readme to learn what it was all about, I spotted this heading did not follow the same level as the other headings corresponding to the directory names. Here's a fix for that.